### PR TITLE
rename ini sections w/o special chars

### DIFF
--- a/config/data.malware-scan.ini
+++ b/config/data.malware-scan.ini
@@ -1,29 +1,33 @@
 ; data.malware-scan.ini
-; use the MALWARE HASH REGISTRY from http://www.team-cymru.org/MHR.html
-; use the MALWARE HASH REGISTRY from https://www.virustotal.com/
-; use the MALWARE HASH REGISTRY from https://www.metascan-online.com/
-; 
+;
+; use the MALWARE HASH REGISTRY from
+;   * http://www.team-cymru.org/MHR.html
+;   * https://www.virustotal.com/
+;   * https://www.metascan-online.com/
+;
 ;...............................................................................
 ;                                                                              .
 ;   ATTENTION:   This plugin will always need a "commercial" key for every     .
 ;   ATTENTION:   service you use. Please read the "Terms of Service" of the    .
-;   ATTENTION:   service used, before you start to use this plugin.            .
+;   ATTENTION:   service used before enabling this plugin.            .
 ;                                                                              .
 ;...............................................................................
 
-[team-cymru.org]
+[cymru]
+; team-cymru.org
 ; run this check
 enabled = false
 ; Check against hash, allowed: md5|sha1
 check_hash = sha1
-; DENY delivery if higher percentage equal to 6% 
-; team-cymru.org use round about 30AV programms 6% = 2 AVs neet 
+; DENY delivery if higher percentage equal to 6%
+; team-cymru.org use round about 30AV programms 6% = 2 AVs neet
 ; to detect to DENY the Mail. 2/30 = 6,667% -> floor(6,667) = 6
 deny_percentage = 6
 ; private api key
 apikey = false
 
-[virustotal.com]
+[virustotal]
+; virustotal.com
 ; run this check
 enabled = false
 ; Check against hash, allowed: md5|sha1|sha256
@@ -33,12 +37,13 @@ deny_results = 2
 ; private or public (mybe with limitations) api key
 apikey = false
 
-[metascan-online.com]
+[metascan]
+;metascan-online.com
 ; run this check
 enabled = false
 ; Check against hash, allowed: md5|sha1|sha256
 check_hash = sha256
-; DENY if more or equal count of results
+; DENY if at least this many results
 deny_results = 2
-; private or public (mybe with limitations) api key
+; private or public (maybe with limits) api key
 apikey = false

--- a/plugins/data.malware-scan.js
+++ b/plugins/data.malware-scan.js
@@ -26,9 +26,42 @@ exports.register = function () {
 exports.load_config = function () {
     var plugin = this;
 
-    plugin.cfg = plugin.config.get('data.malware-scan.ini', function () {
+    plugin.cfg = plugin.config.get('data.malware-scan.ini', {
+        booleans: [
+            '-cymru.enabled',
+            '-virustotal.enabled',
+            '-metascan.enabled',
+        ]
+    },
+    function () {
         plugin.load_config();
     });
+
+    // normalize the config settings once when we read the file (instead of
+    // millions of times during mail processing)
+    if (plugin.cfg.cymru.check_hash) {
+        plugin.cfg.cymru.check_hash =
+        plugin.cfg.cymru.check_hash.toLowerCase();
+    }
+    else {
+        plugin.cfg.cymru.check_hash = 'sha1';
+    }
+
+    if (plugin.cfg.virustotal.check_hash) {
+        plugin.cfg.virustotal.check_hash =
+        plugin.cfg.virustotal.check_hash.toLowerCase();
+    }
+    else {
+        plugin.cfg.virustotal.check_hash = 'sha256';
+    }
+
+    if (plugin.cfg.metascan.check_hash) {
+        plugin.cfg.metascan.check_hash =
+        plugin.cfg.metascan.check_hash.toLowerCase();
+    }
+    else {
+        plugin.cfg.metascan.check_hash = 'sha256';
+    }
 };
 
 exports.start_attachment = function (connection, ctype, filename, body, stream) {
@@ -128,17 +161,17 @@ exports.check_attachments = function (next, connection) {
     var services = [];
     var services_hash = [];
 
-    if (/^(?:1|true|yes|enabled|on)$/i.test(plugin.cfg['team-cymru.org'].enabled)) {
+    if (plugin.cfg.cymru.enabled) {
         services.push(plugin.team_cymru_check);
-        services_hash.push(hashList[(plugin.cfg['team-cymru.org'].check_hash.toLowerCase() || 'sha1')]);
+        services_hash.push(hashList[plugin.cfg.cymru.check_hash]);
     }
-    if (/^(?:1|true|yes|enabled|on)$/i.test(plugin.cfg['virustotal.com'].enabled)) {
+    if (plugin.cfg.virustotal.enabled) {
         services.push(plugin.virustotal_check);
-        services_hash.push(hashList[(plugin.cfg['virustotal.com'].check_hash.toLowerCase() || 'sha256')]);
+        services_hash.push(hashList[plugin.cfg.virustotal.check_hash]);
     }
-    if (/^(?:1|true|yes|enabled|on)$/i.test(plugin.cfg['metascan-online.com'].enabled)) {
+    if (plugin.cfg.metascan.enabled) {
         services.push(plugin.metascan_online_check);
-        services_hash.push(hashList[(plugin.cfg['metascan-online.com'].check_hash.toLowerCase() || 'sha256')]);
+        services_hash.push(hashList[plugin.cfg.metascan.check_hash]);
     }
 
     if (services.length > 0) {
@@ -146,8 +179,8 @@ exports.check_attachments = function (next, connection) {
         for (var i = 0, s = services.length; i < s; i++){
             asyncJob.push((services[i](services_hash[i], plugin, connection)));
         }
-        // Run scan jobs and if one service match deny_results or deny_percentage returned by a TRUE
-        // DENY the mail.
+        // Run scan jobs and if one service match deny_results or
+        // deny_percentage returned by a TRUE, DENY the mail.
         async.parallel(asyncJob, function (err, results) {
             if (results.indexOf(true) !== -1){
                 return next(DENY, 'Message contains unacceptable attachment (MALWARE)');
@@ -163,20 +196,20 @@ exports.check_attachments = function (next, connection) {
 
 
 exports.team_cymru_check = function (hashlist, plugin, conn) {
-    var plugin  = plugin || this;
-    var apikey  = plugin.cfg['team-cymru.org'].apikey || false;
+    if (!plugin) plugin = this;
+    var apikey = plugin.cfg.cymru.apikey || false;
 
     return function(cb){
 
         /*
         // current not implemented
         if (!apikey) {
-            conn.logerror(plugin, 'no APIKEY for team-cymru.org found');
+            conn.logerror(plugin, 'no APIKEY for team-cymru found');
             return cb(null, false);
         }
         */
         if (!hashlist || hashlist.length === 0) {
-            conn.logerror(plugin, 'no hashlist for team-cymru.org found');
+            conn.logerror(plugin, 'no hashlist for cymru found');
             return cb(null, false);
         }
 
@@ -204,7 +237,7 @@ exports.team_cymru_check = function (hashlist, plugin, conn) {
             }
 
             // use only the largest result
-            if (results[0] >= plugin.cfg['team-cymru.org'].deny_percentage) {
+            if (results[0] >= plugin.cfg.cymru.deny_percentage) {
                 if (!next_done) {
                     next_done = true;
                     return cb(null, true);
@@ -221,18 +254,18 @@ exports.team_cymru_check = function (hashlist, plugin, conn) {
 
 
 exports.virustotal_check = function (hashlist, plugin, conn) {
-    var plugin  = plugin || this;
-    var apikey  = plugin.cfg['virustotal.com'].apikey || false;
-    var deny_results  = plugin.cfg['virustotal.com'].deny_results || 2;
+    if (!plugin) plugin = this;
+    var apikey  = plugin.cfg.virustotal.apikey || false;
+    var deny_results  = plugin.cfg.virustotal.deny_results || 2;
 
     return function(cb){
 
         if (!apikey) {
-            conn.logerror(plugin, 'no APIKEY for virustotal.com found');
+            conn.logerror(plugin, 'no APIKEY for virustotal found');
             return cb(null, false);
         }
         if (!hashlist || hashlist.length === 0){
-            conn.logerror(plugin, 'no hashlist for virustotal.com found');
+            conn.logerror(plugin, 'no hashlist for virustotal found');
             return cb(null, false);
         }
 
@@ -253,9 +286,9 @@ exports.virustotal_check = function (hashlist, plugin, conn) {
 };
 
 exports.virustotal_check_post = function (hashlist, plugin, conn){
-    var plugin  = plugin || this;
-    var apikey  = plugin.cfg['virustotal.com'].apikey || false;
-    var deny_results  = plugin.cfg['virustotal.com'].deny_results || 2;
+    if (!plugin) plugin = this;
+    var apikey  = plugin.cfg.virustotal.apikey || false;
+    var deny_results  = plugin.cfg.virustotal.deny_results || 2;
 
     return function(cb){
         var post_data = querystring.stringify({
@@ -280,8 +313,8 @@ exports.virustotal_check_post = function (hashlist, plugin, conn){
                 res.setEncoding('utf8');
                 res.on('data', function (chunk) {
                     try {
-                        if(res.statusCode != 200){
-                            conn.logerror(plugin, 'virustotal.com failure: ' + res.statusCode + ' - ' + res.statusMessage);
+                        if(res.statusCode !== 200){
+                            conn.logerror(plugin, 'virustotal failure: ' + res.statusCode + ' - ' + res.statusMessage);
                             return cb(null, false);
                         }
 
@@ -297,12 +330,12 @@ exports.virustotal_check_post = function (hashlist, plugin, conn){
 
                         }
                     } catch (err) {
-                        conn.logerror(plugin, 'virustotal.com failure: ' + err);
+                        conn.logerror(plugin, 'virustotal failure: ' + err);
                         return cb(null, false);
                     }
                 });
                 res.on('error', function (err) {
-                    conn.logerror(plugin, 'virustotal.com failure: ' + err);
+                    conn.logerror(plugin, 'virustotal failure: ' + err);
                     return cb(null, false);
                 });
             });
@@ -343,18 +376,18 @@ exports.getResultsByVT = function (vtData){
 
 
 exports.metascan_online_check = function (hashlist, plugin, conn) {
-    var plugin  = plugin || this;
-    var apikey  = plugin.cfg['metascan-online.com'].apikey || false;
-    var deny_results  = plugin.cfg['metascan-online.com'].deny_results || 2;
+    if (!plugin) plugin = this;
+    var apikey  = plugin.cfg.metascan.apikey || false;
+    var deny_results  = plugin.cfg.metascan.deny_results || 2;
 
     return function(cb){
 
         if (!apikey) {
-            conn.logerror(plugin, 'no APIKEY for metascan-online.com found');
+            conn.logerror(plugin, 'no APIKEY for metascan found');
             return cb(null, false);
         }
         if (!hashlist || hashlist.length === 0) {
-            conn.logerror(plugin, 'no hashlist for metascan-online.com found');
+            conn.logerror(plugin, 'no hashlist for metascan found');
             return cb(null, false);
         }
 
@@ -380,8 +413,8 @@ exports.metascan_online_check = function (hashlist, plugin, conn) {
                 res.setEncoding('utf8');
                 res.on('data', function (chunk) {
                     try {
-                        if (res.statusCode != 200){
-                            conn.logerror(plugin, 'metascan-online.com failure: ' + res.statusCode + ' - ' + res.statusMessage);
+                        if (res.statusCode !== 200){
+                            conn.logerror(plugin, 'metascan failure: ' + res.statusCode + ' - ' + res.statusMessage);
                             return cb(null, false);
                         }
 
@@ -389,7 +422,7 @@ exports.metascan_online_check = function (hashlist, plugin, conn) {
                         if (results && typeof results === "object" && results !== null) {
 
                             if(results.err){
-                                conn.logerror(plugin, 'metascan-online.com failure: ' + results.err);
+                                conn.logerror(plugin, 'metascan failure: ' + results.err);
                                 return cb(null, false);
                             }
 
@@ -401,19 +434,19 @@ exports.metascan_online_check = function (hashlist, plugin, conn) {
 
                         }
                     } catch (err) {
-                        conn.logerror(plugin, 'metascan-online.com failure: ' + err);
+                        conn.logerror(plugin, 'metascan failure: ' + err);
                         return cb(null, false);
                     }
                 });
                 res.on('error', function (err) {
-                    conn.logerror(plugin, 'metascan-online.com failure: ' + err);
+                    conn.logerror(plugin, 'metascan failure: ' + err);
                     return cb(null, false);
                 });
             });
 
         // post the data and end;
         post_req.end(post_data);
-    }
+    };
 };
 
 exports.getResultsByMetascan = function getResultsByMetascan(msData){


### PR DESCRIPTION
- saves a log of unnecessary typing and punctuation in .js files
- no need to duplicate "truthy" boolean logic
